### PR TITLE
chore: use subdomains for versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "esbuild": "0.15.15",
         "json-schema-to-ts": "2.6.0",
         "serverless": "3.25.1",
+        "serverless-domain-manager": "^6.2.1",
         "serverless-esbuild": "1.33.2",
         "serverless-iam-roles-per-function": "3.2.0",
         "serverless-openapi-documenter": "0.0.26",
@@ -2005,6 +2006,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.1270.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1270.0.tgz",
+      "integrity": "sha512-Dyvcv/cMQxS5ed7wpeDuTZSzRg0ut6bSngHOC+jPiSUyf3LqJI2MnrJMNfcsiVg034bxDVLL5BRI/LfLZc0Ygg==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/axios": {
@@ -6835,6 +6876,18 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/serverless-domain-manager": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/serverless-domain-manager/-/serverless-domain-manager-6.2.1.tgz",
+      "integrity": "sha512-xJ8bOW/e/MUB9twScTDGRlnS0yxW176+ikuR3SjAH4jW/uiZ/dXPdeGTeTFiPZdybzIE4fBZfeeW8CZAEG1OUg==",
+      "dev": true,
+      "dependencies": {
+        "aws-sdk": "^2.1261.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/serverless-esbuild": {
       "version": "1.33.2",
       "resolved": "https://registry.npmjs.org/serverless-esbuild/-/serverless-esbuild-1.33.2.tgz",
@@ -9810,6 +9863,38 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
+    },
+    "aws-sdk": {
+      "version": "2.1270.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1270.0.tgz",
+      "integrity": "sha512-Dyvcv/cMQxS5ed7wpeDuTZSzRg0ut6bSngHOC+jPiSUyf3LqJI2MnrJMNfcsiVg034bxDVLL5BRI/LfLZc0Ygg==",
+      "dev": true,
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "querystring": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+          "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+          "dev": true
+        }
+      }
     },
     "axios": {
       "version": "1.1.3",
@@ -13458,6 +13543,15 @@
           "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
           "dev": true
         }
+      }
+    },
+    "serverless-domain-manager": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/serverless-domain-manager/-/serverless-domain-manager-6.2.1.tgz",
+      "integrity": "sha512-xJ8bOW/e/MUB9twScTDGRlnS0yxW176+ikuR3SjAH4jW/uiZ/dXPdeGTeTFiPZdybzIE4fBZfeeW8CZAEG1OUg==",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "^2.1261.0"
       }
     },
     "serverless-esbuild": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "esbuild": "0.15.15",
     "json-schema-to-ts": "2.6.0",
     "serverless": "3.25.1",
+    "serverless-domain-manager": "6.2.1",
     "serverless-esbuild": "1.33.2",
     "serverless-iam-roles-per-function": "3.2.0",
     "serverless-openapi-documenter": "0.0.26",

--- a/serverless.ts
+++ b/serverless.ts
@@ -37,7 +37,6 @@ const serverlessConfiguration: AWS = {
     discordRedirectUrl: '${self:custom.domain}/api-key/finish',
     customDomain: {
       domainName: '${self:provider.stage}.api.apiempires.com',
-      basePath: '*',
       certificateName: '*.api.apiempires.com',
       stage: '${self:provider.stage}',
       createRoute53Record: true,

--- a/serverless.ts
+++ b/serverless.ts
@@ -34,10 +34,10 @@ const serverlessConfiguration: AWS = {
   custom: {
     domain: 'https://${self:provider.stage}.api.apiempires.com',
     discordClientId: '1043200977156714607',
-    discordRedirectUrl: '${self:custom.domain}/${self:provider.stage}/api-key/finish',
+    discordRedirectUrl: '${self:custom.domain}/api-key/finish',
     customDomain: {
       domainName: '${self:provider.stage}.api.apiempires.com',
-      basePath: '${self:provider.stage}',
+      basePath: '*',
       certificateName: '*.api.apiempires.com',
       stage: '${self:provider.stage}',
       createRoute53Record: true,
@@ -57,7 +57,7 @@ const serverlessConfiguration: AWS = {
       title: 'Trade Game API',
       version: '${self:provider.stage}',
       servers: [{
-        url: "${self:custom.domain}/${self:provider.stage}/",
+        url: "${self:custom.domain}/",
       }],
       security: [{
         name: 'BearerAuthentication',

--- a/serverless.ts
+++ b/serverless.ts
@@ -6,7 +6,7 @@ import * as postHelloSchema from "@functions/hello/schema"
 const serverlessConfiguration: AWS = {
   service: 'trade-game-backend',
   frameworkVersion: '3',
-  plugins: ['serverless-esbuild', 'serverless-plugin-log-retention', 'serverless-iam-roles-per-function', '@motymichaely/serverless-openapi-documentation'],
+  plugins: ['serverless-esbuild', 'serverless-plugin-log-retention', 'serverless-iam-roles-per-function', '@motymichaely/serverless-openapi-documentation', 'serverless-domain-manager'],
   provider: {
     name: 'aws',
     runtime: 'nodejs16.x',
@@ -32,10 +32,17 @@ const serverlessConfiguration: AWS = {
   functions,
   package: { individually: true },
   custom: {
-    // later replace with a shared URL like https://api.tradegame.dev
-    domain: 'https://api.apiempires.com',
+    domain: 'https://${self:provider.stage}.api.apiempires.com',
     discordClientId: '1043200977156714607',
     discordRedirectUrl: '${self:custom.domain}/${self:provider.stage}/api-key/finish',
+    customDomain: {
+      domainName: '${self:provider.stage}.api.apiempires.com',
+      basePath: '${self:provider.stage}',
+      certificateName: '*.api.apiempires.com',
+      stage: '${self:provider.stage}',
+      createRoute53Record: true,
+      autoDomain: true,
+    },
     esbuild: {
       bundle: true,
       minify: false,


### PR DESCRIPTION
After trying to get a proxy working with the version in the path, I decided to go for the version as a subdomain. This should be much easier, and doesn't require a proxy.

Also there might be confusion about the data persisting between versions, however my instance concept has full data isolation.

Instances are now available at e.g. https://pr-52.api.apiempires.com/openapi